### PR TITLE
Corrigido erro 077, e removido Prazo de Entrega

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -186,7 +186,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
 
             foreach ($correiosReturn as $servicos) {
 
-                $errorId = (string) $servicos->Erro;
+                $errorId = empty($servicos->Erro) ? 0 : (string) $servicos->Erro;
                 $errorList[$errorId] = $servicos->MsgErro;
 
                 if ($errorId != '0' && !in_array($errorId, $softErrors)) {
@@ -288,6 +288,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
             $client->setParameterGet('nVlComprimento', $this->_midSize);
             $client->setParameterGet('nVlAltura', $this->_midSize);
             $client->setParameterGet('nVlLargura', $this->_midSize);
+            $client->setParameterGet('nVlDiametro', 0);
 
             if ($this->getConfigData('mao_propria')) {
                 $client->setParameterGet('sCdMaoPropria', 'S');
@@ -340,11 +341,11 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
 
             $xml = new SimpleXMLElement($content);
 
-            if (count($xml->cServico) <= 0) {
+            if (count($xml->Servicos->cServico) <= 0) {
                 throw new Exception('No tag cServico in Correios XML [' . __LINE__ . ']');
             }
 
-            return $xml->cServico;
+            return $xml->Servicos->cServico;
         } catch (Exception $e) {
             $this->_throwError('urlerror', 'URL Error - ' . $e->getMessage(), __LINE__);
             return false;

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -414,7 +414,7 @@
                 <coeficiente_volume>6000</coeficiente_volume>
                 <acobrar_code>40045</acobrar_code>
                 <contrato_codes>40096,81019,41068,41300,40436</contrato_codes>
-                <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx</url_ws_correios>
+                <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx/CalcPreco</url_ws_correios>
 
                 <!-- SRO XML -->
                 <sro_tracking_job>0</sro_tracking_job>
@@ -450,7 +450,7 @@
                 <url_tracking>http://websro.correios.com.br/sro_bin/txect01$.QueryList</url_tracking>
 
                 <!-- CACHE -->
-                <pattern_nocache><![CDATA[/<Erro>(-2|-3|-5|-6|-7|-8|-9|-10|-11|-12|-13|-14|-15|-16|-17|-18|-20|-22|-23|-24|-25|-26|-27|-28|-29|-30|-31|-32|-33|-34|-35|-36|-37|-38|-39|-40|-41|-42|-43|-44|-45|-888|006|007|009|010|011|7|99)<\/Erro>/]]></pattern_nocache>
+                <pattern_nocache><![CDATA[/<Erro>(-2|-3|-5|-6|-7|-8|-9|-10|-11|-12|-13|-14|-15|-16|-17|-18|-20|-22|-23|-24|-25|-26|-27|-28|-29|-30|-31|-32|-33|-34|-35|-36|-37|-38|-39|-40|-41|-42|-43|-44|-45|-888|006|007|009|010|011|077|7|99)<\/Erro>/]]></pattern_nocache>
                 <cache_timeout>31536000</cache_timeout>
                 <cache_accuracy>
                     <weight>1</weight>


### PR DESCRIPTION
Conforme a issue #182, os Correios desfizeram a última alteração, onde não era mais possível cotar frete através do webservice _ws.correios.com.br/calculador/CalcPrecoPrazo.aspx_.

![image](https://cloud.githubusercontent.com/assets/13813964/18057993/b65eaeb2-6de8-11e6-854c-208edb569faa.png)

O manual fornecido pelos Correios não exibe qualquer orientação. O erro 077 sequer existe. 
![image](https://cloud.githubusercontent.com/assets/13813964/18069197/d3fbca62-6e1b-11e6-8b53-230c642687c8.png)

Enfim, vou deixar esse branch preparado. **Caso os Correios queiram repetir o estrago que fizeram nas vendas de hoje, esse patch vai ajudar a manter as cotações funcionando.**

* Testado na versão 1.9.1.0 apenas para os serviços PAC e SEDEX.

_Importante: Nesse patch o prazo de entrega não funciona. E o logista deve desabilitar a exibição do prazo nas configurações do módulo, sob pena de comprometer a cotação._